### PR TITLE
「保存」ボタンでProsetsリストが更新されるようにしました

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.classpath
+.project
+.settings/
+.externalToolBuilders/
+/javadoc/
+/build/

--- a/src/org/maripo/josm/easypresets/EasyPresetsPlugin.java
+++ b/src/org/maripo/josm/easypresets/EasyPresetsPlugin.java
@@ -14,7 +14,6 @@ import org.openstreetmap.josm.plugins.PluginInformation;
 
 public class EasyPresetsPlugin extends Plugin {
 
-	@SuppressWarnings("deprecation")
 	public EasyPresetsPlugin (PluginInformation info) {
 		super(info);
 

--- a/src/org/maripo/josm/easypresets/EasyPresetsPlugin.java
+++ b/src/org/maripo/josm/easypresets/EasyPresetsPlugin.java
@@ -5,26 +5,33 @@ import javax.swing.JSeparator;
 
 import org.maripo.josm.easypresets.data.EasyPresets;
 import org.maripo.josm.easypresets.ui.CreatePresetAction;
+import org.maripo.josm.easypresets.ui.GroupPresetMenu;
 import org.maripo.josm.easypresets.ui.ManagePresetsAction;
 import org.openstreetmap.josm.gui.MainApplication;
 import org.openstreetmap.josm.gui.MainMenu;
-import org.openstreetmap.josm.gui.tagging.presets.TaggingPresetMenu;
 import org.openstreetmap.josm.plugins.Plugin;
 import org.openstreetmap.josm.plugins.PluginInformation;
 
 public class EasyPresetsPlugin extends Plugin {
+	public static EasyPresets presets;
+	public static GroupPresetMenu groupMenu;
 
 	public EasyPresetsPlugin (PluginInformation info) {
 		super(info);
+		
+		presets = EasyPresets.getInstance();
+        presets.load();
 
         // Add custom presets to "Presets" menu
 		JMenu menu = MainApplication.getMenu().presetsMenu;
         menu.add(new JSeparator());
         MainMenu.add(menu, new CreatePresetAction());
         MainMenu.add(menu, new ManagePresetsAction());
+        
         // Group for all custom presets
-        TaggingPresetMenu groupMenu = EasyPresets.getInstance().createGroupMenu();
-		EasyPresets.getInstance().load();
+        groupMenu = new GroupPresetMenu();
+        groupMenu.updatePresetListMenu(presets);
         menu.add(groupMenu.menu);
 	}
+	
 }

--- a/src/org/maripo/josm/easypresets/data/EasyPreset.java
+++ b/src/org/maripo/josm/easypresets/data/EasyPreset.java
@@ -1,0 +1,107 @@
+package org.maripo.josm.easypresets.data;
+
+import static org.openstreetmap.josm.tools.I18n.tr;
+
+import java.util.EnumSet;
+
+import org.openstreetmap.josm.gui.tagging.presets.TaggingPreset;
+import org.openstreetmap.josm.gui.tagging.presets.TaggingPresetItem;
+import org.openstreetmap.josm.gui.tagging.presets.TaggingPresetType;
+import org.openstreetmap.josm.gui.tagging.presets.items.Check;
+import org.openstreetmap.josm.gui.tagging.presets.items.Combo;
+import org.openstreetmap.josm.gui.tagging.presets.items.Key;
+import org.openstreetmap.josm.gui.tagging.presets.items.Label;
+import org.openstreetmap.josm.gui.tagging.presets.items.Link;
+import org.openstreetmap.josm.gui.tagging.presets.items.MultiSelect;
+import org.openstreetmap.josm.gui.tagging.presets.items.Text;
+
+public class EasyPreset extends TaggingPreset implements Cloneable {
+	private static final long serialVersionUID = -7626914563011340418L;
+
+	public EasyPreset() {
+		super();
+	}
+	
+	public static EasyPreset copy(TaggingPreset src) {
+		EasyPreset preset = EasyPreset.clone(src);
+		preset.name = tr("Copy of {0}", src.name);
+		return preset;
+	}
+
+	public static EasyPreset getInstance(TaggingPreset src) {
+		return EasyPreset.clone(src);
+	}
+	
+	@Override
+	public EasyPreset clone() {
+		return EasyPreset.clone(this);
+	}
+	
+	public static EasyPreset clone(TaggingPreset src) {
+		EasyPreset preset = new EasyPreset();
+		preset.name = src.name;
+		preset.setIcon(src.iconName);
+		for (TaggingPresetItem fromItem: src.data) {
+			TaggingPresetItem item = clonePresetTag(fromItem);
+			if (item != null) {
+				preset.data.add(item);
+			}
+		}
+		preset.types = EnumSet.noneOf(TaggingPresetType.class);
+		preset.types.addAll(src.types);
+		return preset;
+	}
+	
+	private static TaggingPresetItem clonePresetTag(TaggingPresetItem itemFrom) {
+		if (itemFrom instanceof Label) {
+			Label itemTo = new Label();
+			itemTo.text = ((Label) itemFrom).text;
+			return itemTo;
+		}
+		else if (itemFrom instanceof Key) {
+			Key key = (Key) itemFrom;
+			Key itemTo = new Key();
+			itemTo.key = key.key;
+			itemTo.value = key.value;
+			return itemTo;
+		}
+		else if (itemFrom instanceof Text) {
+			Text text = (Text)itemFrom;
+			Text itemTo = new Text();
+			itemTo.text = text.text;
+			itemTo.key = text.key;
+			itemTo.default_ = text.default_;
+			return itemTo;
+		}
+		else if (itemFrom instanceof Combo) {
+			Combo combo = (Combo)itemFrom;
+			Combo itemTo = new Combo();
+			itemTo.text = combo.text;
+			itemTo.key = combo.key;
+			itemTo.values = combo.values;
+			return itemTo;
+		}
+		else if (itemFrom instanceof MultiSelect) {
+			MultiSelect multiselect = (MultiSelect)itemFrom;
+			MultiSelect itemTo = new MultiSelect();
+			itemTo.text = multiselect.text;
+			itemTo.key = multiselect.key;
+			itemTo.values = multiselect.values;
+			return itemTo;
+		}
+		else if (itemFrom instanceof Check) {
+			Check key = (Check) itemFrom;
+			Check itemTo = new Check();
+			itemTo.text = key.text;
+			itemTo.key = key.key;
+			return itemTo;
+		}
+		else if (itemFrom instanceof Link) {
+			Link link = (Link)itemFrom;
+			Link itemTo = new Link();
+			itemTo.href = link.href;
+			return itemTo;
+		}
+		return null;
+	}
+}

--- a/src/org/maripo/josm/easypresets/data/EasyPreset.java
+++ b/src/org/maripo/josm/easypresets/data/EasyPreset.java
@@ -48,7 +48,9 @@ public class EasyPreset extends TaggingPreset implements Cloneable {
 			}
 		}
 		preset.types = EnumSet.noneOf(TaggingPresetType.class);
-		preset.types.addAll(src.types);
+		if (src.types != null) {
+			preset.types.addAll(src.types);
+		}
 		return preset;
 	}
 	

--- a/src/org/maripo/josm/easypresets/data/EasyPresets.java
+++ b/src/org/maripo/josm/easypresets/data/EasyPresets.java
@@ -11,7 +11,6 @@ import java.io.Reader;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -54,7 +53,7 @@ import org.xml.sax.SAXException;
  *
  */
 @SuppressWarnings("serial")
-public class EasyPresets extends DefaultListModel<TaggingPreset> implements Iterable<TaggingPreset> {
+public class EasyPresets extends DefaultListModel<TaggingPreset> {
 	private static final String FILE_NAME = "EasyPresets.xml";
 	private static final String[] PRESET_FORMAT_URLS = {
 			"https://josm.openstreetmap.de/wiki/TaggingPresets",
@@ -84,8 +83,6 @@ public class EasyPresets extends DefaultListModel<TaggingPreset> implements Iter
 		return instance;
 	}
 
-	List<TaggingPreset> list = new ArrayList<TaggingPreset>();
-
 	/**
 	 * Load custom presets from local XML (if exists)
 	 */
@@ -95,7 +92,7 @@ public class EasyPresets extends DefaultListModel<TaggingPreset> implements Iter
 			try (Reader reader = UTFInputStreamReader.create(new FileInputStream(file))) {
 				final Collection<TaggingPreset> readResult = TaggingPresetReader.readAll(reader, true);
 				if (readResult != null) {
-					list.addAll(readResult);
+					this.addAll(readResult);
 				}
 				TaggingPresets.addTaggingPresets(readResult);
 			} catch (FileNotFoundException e) {
@@ -113,33 +110,26 @@ public class EasyPresets extends DefaultListModel<TaggingPreset> implements Iter
 	 */
 	@Override
 	public void addElement(TaggingPreset preset) {
-		list.add(preset);
+		this.addElement(preset);
 		Collection<TaggingPreset> toAdd = new ArrayList<TaggingPreset>();
 		toAdd.add(preset);
 		// New preset will be able to find F3 menu
 		TaggingPresets.addTaggingPresets(toAdd);
 	}
 	
-	@Override
-	public int size() {
-		return list.size();
-	}
-
-
 	/**
 	 * Save all presets to specified file
 	 * @param file
 	 */
 	public void saveAllPresetsTo(File file) {
+		List<TaggingPreset> list = new ArrayList<TaggingPreset>();
+		for (TaggingPreset preset: list) {
+			list.add(preset);
+		}
 		saveTo(list, file);
 	}
 	
-	/**
-	 * Save presets to specified file
-	 * @param presetsToSave
-	 * @param file
-	 */
-	public void saveTo(List<TaggingPreset> presetsToSave, File file) {
+	public void saveTo(List<TaggingPreset> list, File file) {
 		try {
 			DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();
 			DocumentBuilder docBuilder = docFactory.newDocumentBuilder();
@@ -153,7 +143,7 @@ public class EasyPresets extends DefaultListModel<TaggingPreset> implements Iter
 			rootElement.setAttribute("shortdescription", "");
 			doc.appendChild(rootElement);
 			rootElement.appendChild(doc.createComment(getComment()));
-			for (TaggingPreset preset: presetsToSave) {
+			for (TaggingPreset preset: list) {
 				Element presetElement = createpresetElement(doc, preset);
 				rootElement.appendChild(presetElement);
 			}
@@ -166,7 +156,6 @@ public class EasyPresets extends DefaultListModel<TaggingPreset> implements Iter
 			// Write to local XML
 			StreamResult result = new StreamResult(file);
 			transformer.transform(source, result);
-			
 		} catch (ParserConfigurationException e) {
 			e.printStackTrace();
 		} catch (TransformerConfigurationException e) {
@@ -273,19 +262,10 @@ public class EasyPresets extends DefaultListModel<TaggingPreset> implements Iter
 
 	@Override
 	public TaggingPreset lastElement() {
-		if (list.isEmpty()) {
+		if (isEmpty()) {
 			return null;
 		}
-		return list.get(list.size()-1);
-	}
-
-	public Collection<TaggingPreset> getPresets() {
-		return list;
-	}
-
-	@Override
-	public boolean removeElement(Object presetToRemove) {
-		return list.remove(presetToRemove);
+		return getElementAt(size()-1);
 	}
 
 	/**
@@ -293,11 +273,11 @@ public class EasyPresets extends DefaultListModel<TaggingPreset> implements Iter
 	 * @param index
 	 */
 	public void moveDown(int index) {
-		if (index >= list.size()-1) {
+		if (index >= size()-1) {
 			return;
 		}
-		TaggingPreset presetToMove = list.remove(index);
-		list.add(index+1, presetToMove);
+		TaggingPreset presetToMove = remove(index);
+		add(index+1, presetToMove);
 		isDirty = true;
 	}
 
@@ -309,8 +289,8 @@ public class EasyPresets extends DefaultListModel<TaggingPreset> implements Iter
 		if (index <= 0) {
 			return;
 		}
-		TaggingPreset presetToMove = list.remove(index);
-		list.add(index-1, presetToMove);
+		TaggingPreset presetToMove = remove(index);
+		add(index-1, presetToMove);
 		isDirty = true;
 	}
 	
@@ -369,10 +349,5 @@ public class EasyPresets extends DefaultListModel<TaggingPreset> implements Iter
 					item.locale_text:DummyPresetClass.getLocaleText(item.text, item.text_context);
 		}
 		return null;
-	}
-
-	@Override
-	public Iterator<TaggingPreset> iterator() {
-		return list.iterator();
 	}
 }

--- a/src/org/maripo/josm/easypresets/data/EasyPresets.java
+++ b/src/org/maripo/josm/easypresets/data/EasyPresets.java
@@ -10,11 +10,11 @@ import org.openstreetmap.josm.io.UTFInputStreamReader;
 import java.io.Reader;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import javax.swing.DefaultListModel;
 import javax.swing.JMenu;
 import javax.swing.JMenuItem;
 import javax.xml.parsers.DocumentBuilder;
@@ -55,7 +55,8 @@ import org.xml.sax.SAXException;
  * @author maripo
  *
  */
-public class EasyPresets {
+@SuppressWarnings("serial")
+public class EasyPresets extends DefaultListModel<TaggingPreset> {
 	private static final String FILE_NAME = "EasyPresets.xml";
 	private static final String[] PRESET_FORMAT_URLS = {
 			"https://josm.openstreetmap.de/wiki/TaggingPresets",
@@ -63,7 +64,7 @@ public class EasyPresets {
 			};
 	public static final String PLUGIN_HELP_URL = "https://github.com/maripo/JOSM_easypresets/blob/master/README.md";
 
-	boolean isDirty = false;
+	public boolean isDirty = false;
 	/**
 	 * Get file path of custom preset data file
 	 * @return Full path of preset data file
@@ -113,7 +114,8 @@ public class EasyPresets {
 	 * Add new tagging preset
 	 * @param preset
 	 */
-	public void add (TaggingPreset preset) {
+	@Override
+	public void addElement(TaggingPreset preset) {
 		presets.add(preset);
 		Collection<TaggingPreset> toAdd = new ArrayList<TaggingPreset>();
 		toAdd.add(preset);
@@ -129,6 +131,7 @@ public class EasyPresets {
 	public void saveAllPresetsTo(File file) {
 		saveTo(presets, file);
 	}
+	
 	/**
 	 * Save presets to specified file
 	 * @param presetsToSave
@@ -296,24 +299,25 @@ public class EasyPresets {
 		return presetElement;
 	}
 
-	public TaggingPreset getLastItem() {
-		if (presets.size()==0) {
+	@Override
+	public TaggingPreset lastElement() {
+		if (presets.isEmpty()) {
 			return null;
 		}
-		Object[] objs = presets.toArray();
-		return (TaggingPreset)objs[objs.length-1];
+		return presets.get(presets.size()-1);
 	}
 
 	public Collection<TaggingPreset> getPresets() {
 		return presets;
 	}
 
-	public void remove(TaggingPreset presetToRemove) {
-		presets.remove(presetToRemove);
+	@Override
+	public boolean removeElement(Object presetToRemove) {
+		return presets.remove(presetToRemove);
 	}
 
 	public void delete(TaggingPreset presetToDelete) {
-		remove(presetToDelete);
+		removeElement(presetToDelete);
 		save();
 		updatePresetListMenu();
 	}
@@ -343,7 +347,6 @@ public class EasyPresets {
 		TaggingPreset presetToMove = presets.remove(index);
 		presets.add(index-1, presetToMove);
 		isDirty = true;
-		
 	}
 	
 	public String getLabelFromExistingPresets (String key) {
@@ -399,84 +402,6 @@ public class EasyPresets {
 			Check item = (Check)_item;
 			return (item.locale_text!=null)?
 					item.locale_text:DummyPresetClass.getLocaleText(item.text, item.text_context);
-		}
-		return null;
-	}
-
-	public TaggingPreset duplicate(TaggingPreset fromPreset) {
-		int index = presets.indexOf(fromPreset);
-		TaggingPreset toPreset = clonePreset(fromPreset); 
-		presets.add(index+1, toPreset);
-		return toPreset;
-		
-	}
-
-	private TaggingPreset clonePreset(TaggingPreset fromPreset) {
-		TaggingPreset preset = new TaggingPreset();
-		preset.name = tr("Copy of {0}", fromPreset.name);
-		preset.setIcon(fromPreset.iconName);
-		for (TaggingPresetItem fromItem: fromPreset.data) {
-			TaggingPresetItem item = clonePresetTag(fromItem);
-			if (item != null) {
-				preset.data.add(item);
-			}
-		}
-		preset.types = EnumSet.noneOf(TaggingPresetType.class);
-		preset.types.addAll(fromPreset.types);
-		isDirty = true;
-		return preset;
-	}
-
-	private TaggingPresetItem clonePresetTag(TaggingPresetItem itemFrom) {
-		if (itemFrom instanceof Label) {
-			Label itemTo = new Label(); 
-			itemTo.text = ((Label) itemFrom).text;
-			return itemTo;
-		}
-		else if (itemFrom instanceof Key) {
-			Key key = (Key) itemFrom;
-			Key itemTo = new Key();
-			itemTo.key = key.key;
-			itemTo.value = key.value;
-			return itemTo;
-		}
-		else if (itemFrom instanceof Text) {
-			Text text = (Text)itemFrom;
-			Text itemTo = new Text();
-			itemTo.text = text.text;
-			itemTo.key = text.key;
-			itemTo.default_ = text.default_;
-			return itemTo;
-		}
-		else if (itemFrom instanceof Combo) {
-			Combo combo = (Combo)itemFrom;
-			Combo itemTo = new Combo();
-			itemTo.text = combo.text;
-			itemTo.key = combo.key;
-			itemTo.values = combo.values;
-			return itemTo;
-		}
-		else if (itemFrom instanceof MultiSelect) {
-			MultiSelect multiselect = (MultiSelect)itemFrom;
-			MultiSelect itemTo = new MultiSelect();
-			itemTo.text = multiselect.text;
-			itemTo.key = multiselect.key;
-			itemTo.values = multiselect.values;
-			return itemTo;
-		}
-		else if (itemFrom instanceof Check) {
-			Check key = (Check) itemFrom;
-			Check itemTo = new Check();
-			itemTo.text = key.text;
-			itemTo.key = key.key;
-			return itemTo;
-		}
-		else if (itemFrom instanceof Link) {
-			Link link = (Link)itemFrom;
-			Link itemTo = new Link();
-			itemTo.href = link.href;
-
-			return itemTo;
 		}
 		return null;
 	}

--- a/src/org/maripo/josm/easypresets/data/EasyPresets.java
+++ b/src/org/maripo/josm/easypresets/data/EasyPresets.java
@@ -110,7 +110,7 @@ public class EasyPresets extends DefaultListModel<TaggingPreset> {
 	 */
 	@Override
 	public void addElement(TaggingPreset preset) {
-		this.addElement(preset);
+		super.addElement(preset);
 		Collection<TaggingPreset> toAdd = new ArrayList<TaggingPreset>();
 		toAdd.add(preset);
 		// New preset will be able to find F3 menu
@@ -266,6 +266,15 @@ public class EasyPresets extends DefaultListModel<TaggingPreset> {
 			return null;
 		}
 		return getElementAt(size()-1);
+	}
+	
+	@Override
+	public TaggingPreset[] toArray() {
+		ArrayList<TaggingPreset> list = new ArrayList<TaggingPreset>();
+		for (int i = 0; i < getSize(); i++) {
+			list.add(getElementAt(i));
+		}
+		return list.toArray(new TaggingPreset[getSize()]);
 	}
 
 	/**

--- a/src/org/maripo/josm/easypresets/data/EasyPresets.java
+++ b/src/org/maripo/josm/easypresets/data/EasyPresets.java
@@ -122,11 +122,14 @@ public class EasyPresets extends DefaultListModel<TaggingPreset> {
 	 * @param file
 	 */
 	public void saveAllPresetsTo(File file) {
+		TaggingPreset[] arr = this.toArray();
 		List<TaggingPreset> list = new ArrayList<TaggingPreset>();
-		for (TaggingPreset preset: list) {
+		for (TaggingPreset preset: arr) {
 			list.add(preset);
 		}
-		saveTo(list, file);
+		if (!list.isEmpty()) {
+			saveTo(list, file);
+		}
 	}
 	
 	public void saveTo(List<TaggingPreset> list, File file) {

--- a/src/org/maripo/josm/easypresets/data/EasyPresets.java
+++ b/src/org/maripo/josm/easypresets/data/EasyPresets.java
@@ -117,6 +117,11 @@ public class EasyPresets extends DefaultListModel<TaggingPreset> {
 		TaggingPresets.addTaggingPresets(toAdd);
 	}
 	
+	@Override
+	public void setElementAt(TaggingPreset element, int index) {
+		super.setElementAt(element, index);
+	}
+	
 	/**
 	 * Save all presets to specified file
 	 * @param file

--- a/src/org/maripo/josm/easypresets/data/EasyPresets.java
+++ b/src/org/maripo/josm/easypresets/data/EasyPresets.java
@@ -60,8 +60,6 @@ public class EasyPresets {
 			};
 	public static final String PLUGIN_HELP_URL = "https://github.com/maripo/JOSM_easypresets/blob/master/README.md";
 
-	boolean isDirty = false;
-	
 	/**
 	 * Get file path of custom preset data file
 	 * @return Full path of preset data file
@@ -148,7 +146,7 @@ public class EasyPresets {
 	 * Save all presets to specified file
 	 * @param file
 	 */
-	public void saveAllPresetsTo(File file) {
+	private void saveAllPresetsTo(File file) {
 		List<TaggingPreset> list = getPresets();
 		if (!list.isEmpty()) {
 			saveTo(list, file);
@@ -207,14 +205,8 @@ public class EasyPresets {
 		return comment.toString();
 	}
 
-	public void saveIfNeeded() {
-		if (isDirty) {
-			save();
-		}
-	}
 	public void save() {
 		saveAllPresetsTo(new File(EasyPresets.getInstance().getXMLPath()));
-		isDirty = false;
 		TaggingPresetNameTemplateList.getInstance().taggingPresetsModified();
 	}
 	
@@ -296,7 +288,6 @@ public class EasyPresets {
 		}
 		TaggingPreset presetToMove = model.remove(index);
 		model.add(index+1, presetToMove);
-		isDirty = true;
 	}
 
 	/**
@@ -309,7 +300,6 @@ public class EasyPresets {
 		}
 		TaggingPreset presetToMove = model.remove(index);
 		model.add(index-1, presetToMove);
-		isDirty = true;
 	}
 	
 	public String getLabelFromExistingPresets (String key) {

--- a/src/org/maripo/josm/easypresets/data/EasyPresets.java
+++ b/src/org/maripo/josm/easypresets/data/EasyPresets.java
@@ -52,8 +52,7 @@ import org.xml.sax.SAXException;
  * @author maripo
  *
  */
-@SuppressWarnings("serial")
-public class EasyPresets extends DefaultListModel<TaggingPreset> {
+public class EasyPresets {
 	private static final String FILE_NAME = "EasyPresets.xml";
 	private static final String[] PRESET_FORMAT_URLS = {
 			"https://josm.openstreetmap.de/wiki/TaggingPresets",
@@ -61,7 +60,8 @@ public class EasyPresets extends DefaultListModel<TaggingPreset> {
 			};
 	public static final String PLUGIN_HELP_URL = "https://github.com/maripo/JOSM_easypresets/blob/master/README.md";
 
-	public boolean isDirty = false;
+	boolean isDirty = false;
+	
 	/**
 	 * Get file path of custom preset data file
 	 * @return Full path of preset data file
@@ -71,9 +71,11 @@ public class EasyPresets extends DefaultListModel<TaggingPreset> {
 	}
 
 	private static EasyPresets instance;
+	private DefaultListModel<TaggingPreset> model;
 
 	private EasyPresets() {
 		super();
+		model = new DefaultListModel<TaggingPreset>();
 	}
 
 	public static EasyPresets getInstance() {
@@ -81,6 +83,24 @@ public class EasyPresets extends DefaultListModel<TaggingPreset> {
 			instance = new EasyPresets();
 		}
 		return instance;
+	}
+	
+	public DefaultListModel<TaggingPreset> getModel() {
+		return this.model;
+	}
+	
+	public List<TaggingPreset> getPresets() {
+		List<TaggingPreset> list = new ArrayList<TaggingPreset>();
+		for (int i = 0; i < model.getSize(); i++) {
+			TaggingPreset e = model.getElementAt(i);
+			list.add(e);
+		}
+		return list;
+	}
+	
+	public TaggingPreset[] toArray() {
+		List<TaggingPreset> list = getPresets();
+		return (TaggingPreset[])list.toArray(new TaggingPreset[list.size()]);
 	}
 
 	/**
@@ -92,7 +112,7 @@ public class EasyPresets extends DefaultListModel<TaggingPreset> {
 			try (Reader reader = UTFInputStreamReader.create(new FileInputStream(file))) {
 				final Collection<TaggingPreset> readResult = TaggingPresetReader.readAll(reader, true);
 				if (readResult != null) {
-					this.addAll(readResult);
+					model.addAll(readResult);
 				}
 				TaggingPresets.addTaggingPresets(readResult);
 			} catch (FileNotFoundException e) {
@@ -103,23 +123,25 @@ public class EasyPresets extends DefaultListModel<TaggingPreset> {
 			}
 		}
 	}
+	
+	public int size() {
+		return getModel().getSize();
+	}
 
 	/**
 	 * Add new tagging preset
 	 * @param preset
 	 */
-	@Override
 	public void addElement(TaggingPreset preset) {
-		super.addElement(preset);
+		model.addElement(preset);
 		Collection<TaggingPreset> toAdd = new ArrayList<TaggingPreset>();
 		toAdd.add(preset);
 		// New preset will be able to find F3 menu
 		TaggingPresets.addTaggingPresets(toAdd);
 	}
 	
-	@Override
 	public void setElementAt(TaggingPreset element, int index) {
-		super.setElementAt(element, index);
+		model.setElementAt(element, index);
 	}
 	
 	/**
@@ -127,11 +149,7 @@ public class EasyPresets extends DefaultListModel<TaggingPreset> {
 	 * @param file
 	 */
 	public void saveAllPresetsTo(File file) {
-		TaggingPreset[] arr = this.toArray();
-		List<TaggingPreset> list = new ArrayList<TaggingPreset>();
-		for (TaggingPreset preset: arr) {
-			list.add(preset);
-		}
+		List<TaggingPreset> list = getPresets();
 		if (!list.isEmpty()) {
 			saveTo(list, file);
 		}
@@ -268,33 +286,16 @@ public class EasyPresets extends DefaultListModel<TaggingPreset> {
 		return presetElement;
 	}
 
-	@Override
-	public TaggingPreset lastElement() {
-		if (isEmpty()) {
-			return null;
-		}
-		return getElementAt(size()-1);
-	}
-	
-	@Override
-	public TaggingPreset[] toArray() {
-		ArrayList<TaggingPreset> list = new ArrayList<TaggingPreset>();
-		for (int i = 0; i < getSize(); i++) {
-			list.add(getElementAt(i));
-		}
-		return list.toArray(new TaggingPreset[getSize()]);
-	}
-
 	/**
 	 * Reorder presets
 	 * @param index
 	 */
 	public void moveDown(int index) {
-		if (index >= size()-1) {
+		if (index >= model.getSize() - 1) {
 			return;
 		}
-		TaggingPreset presetToMove = remove(index);
-		add(index+1, presetToMove);
+		TaggingPreset presetToMove = model.remove(index);
+		model.add(index+1, presetToMove);
 		isDirty = true;
 	}
 
@@ -306,8 +307,8 @@ public class EasyPresets extends DefaultListModel<TaggingPreset> {
 		if (index <= 0) {
 			return;
 		}
-		TaggingPreset presetToMove = remove(index);
-		add(index-1, presetToMove);
+		TaggingPreset presetToMove = model.remove(index);
+		model.add(index-1, presetToMove);
 		isDirty = true;
 	}
 	

--- a/src/org/maripo/josm/easypresets/ui/ExportDialog.java
+++ b/src/org/maripo/josm/easypresets/ui/ExportDialog.java
@@ -27,11 +27,13 @@ import org.openstreetmap.josm.gui.tagging.presets.TaggingPreset;
 import org.openstreetmap.josm.tools.GBC;
 
 public class ExportDialog extends ExtendedDialog {
-
+	private static final long serialVersionUID = -1147760276640641360L;
+	
 	public ExportDialog () {
 		super(MainApplication.getMainFrame(), tr("Export"));
 		initUI();
 	}
+
 	JLabel alertLabel;
 	static class PresetWrapper {
 		JCheckBox checkbox;
@@ -54,6 +56,7 @@ public class ExportDialog extends ExtendedDialog {
 		}
 		
 	}
+
 	List<PresetWrapper> wrappers = new ArrayList<PresetWrapper>();
 	private void initUI() {
 		JPanel listPane = new JPanel(new GridBagLayout());

--- a/src/org/maripo/josm/easypresets/ui/ExportDialog.java
+++ b/src/org/maripo/josm/easypresets/ui/ExportDialog.java
@@ -158,12 +158,6 @@ public class ExportDialog extends ExtendedDialog {
         }
 	}
 	
-	@Override
-	public void dispose() {
-		EasyPresets.getInstance().saveIfNeeded();
-		super.dispose();
-	}
-	
 	protected void cancel() {
 		dispose();
 	}

--- a/src/org/maripo/josm/easypresets/ui/ExportDialog.java
+++ b/src/org/maripo/josm/easypresets/ui/ExportDialog.java
@@ -54,7 +54,6 @@ public class ExportDialog extends ExtendedDialog {
 		public Component getLabel() {
 			return label;
 		}
-		
 	}
 
 	List<PresetWrapper> wrappers = new ArrayList<PresetWrapper>();
@@ -65,8 +64,9 @@ public class ExportDialog extends ExtendedDialog {
 
 		final JPanel list = new JPanel(new GridBagLayout());
 		list.setBackground(Color.WHITE);
-		for (TaggingPreset preset: EasyPresets.getInstance().getPresets()) {
-			PresetWrapper wrapper = new PresetWrapper(preset);
+		TaggingPreset[] array = (TaggingPreset[]) EasyPresets.getInstance().toArray();
+        for (int i = 0; i < array.length; i++) {
+			PresetWrapper wrapper = new PresetWrapper(array[i]);
 			list.add(wrapper.getCheckbox());
 			list.add(wrapper.getLabel(), GBC.eol().fill());
 			wrappers.add(wrapper);
@@ -142,7 +142,6 @@ public class ExportDialog extends ExtendedDialog {
 				selectedPresets.add(wrapper.preset);
 			}
 		}
-		
 		
 		if (selectedPresets.isEmpty()) {
 			alertLabel.setText(tr("No presets are selected."));

--- a/src/org/maripo/josm/easypresets/ui/GroupPresetMenu.java
+++ b/src/org/maripo/josm/easypresets/ui/GroupPresetMenu.java
@@ -27,9 +27,10 @@ public class GroupPresetMenu extends TaggingPresetMenu {
 	public void updatePresetListMenu(EasyPresets presets) {
 		setEnabled(presets.size()>0);
 		menu.removeAll();
-        for (TaggingPreset preset: presets) {
-            JMenuItem mi = new JMenuItem(preset);
-            mi.setText(preset.getLocaleName());
+		TaggingPreset[] array = (TaggingPreset[]) presets.toArray();
+        for (int i = 0; i < array.length; i++) {
+            JMenuItem mi = new JMenuItem(array[i]);
+            mi.setText(array[i].getLocaleName());
             menu.add(mi);
         }
 	}

--- a/src/org/maripo/josm/easypresets/ui/GroupPresetMenu.java
+++ b/src/org/maripo/josm/easypresets/ui/GroupPresetMenu.java
@@ -1,0 +1,39 @@
+package org.maripo.josm.easypresets.ui;
+
+import static org.openstreetmap.josm.tools.I18n.tr;
+
+import javax.swing.JMenu;
+import javax.swing.JMenuItem;
+
+import org.maripo.josm.easypresets.data.EasyPresets;
+import org.openstreetmap.josm.gui.tagging.presets.TaggingPreset;
+import org.openstreetmap.josm.gui.tagging.presets.TaggingPresetMenu;
+
+@SuppressWarnings("serial")
+public class GroupPresetMenu extends TaggingPresetMenu {
+
+	/**
+	 * Create a preset group holding all custom presets
+	 * @return created group
+	 */
+	public GroupPresetMenu() {
+		super();
+		name = tr("Custom Presets");
+		setIcon("easypresets.png");
+		menu = new JMenu(group);
+		setDisplayName();
+	}
+
+	public void updatePresetListMenu(EasyPresets presets) {
+		setEnabled(presets.size()>0);
+		menu.removeAll();
+        for (TaggingPreset preset: presets) {
+            JMenuItem mi = new JMenuItem(preset);
+            mi.setText(preset.getLocaleName());
+            mi.setEnabled(true);
+            menu.add(mi);
+            menu.setEnabled(true);
+        }
+	}
+	
+}

--- a/src/org/maripo/josm/easypresets/ui/GroupPresetMenu.java
+++ b/src/org/maripo/josm/easypresets/ui/GroupPresetMenu.java
@@ -20,7 +20,7 @@ public class GroupPresetMenu extends TaggingPresetMenu {
 		super();
 		name = tr("Custom Presets");
 		setIcon("easypresets.png");
-		menu = new JMenu(group);
+		menu = new JMenu(name);
 		setDisplayName();
 	}
 
@@ -30,9 +30,7 @@ public class GroupPresetMenu extends TaggingPresetMenu {
         for (TaggingPreset preset: presets) {
             JMenuItem mi = new JMenuItem(preset);
             mi.setText(preset.getLocaleName());
-            mi.setEnabled(true);
             menu.add(mi);
-            menu.setEnabled(true);
         }
 	}
 	

--- a/src/org/maripo/josm/easypresets/ui/ManagePresetsAction.java
+++ b/src/org/maripo/josm/easypresets/ui/ManagePresetsAction.java
@@ -16,6 +16,7 @@ public class ManagePresetsAction extends JosmAction {
 	
 	@Override
 	public void actionPerformed(ActionEvent e) {
-		new ManagePresetsDialog().showDialog();
+		ManagePresetsDialog dialog = new ManagePresetsDialog();
+		dialog.showDialog();
 	}
 }

--- a/src/org/maripo/josm/easypresets/ui/ManagePresetsAction.java
+++ b/src/org/maripo/josm/easypresets/ui/ManagePresetsAction.java
@@ -1,11 +1,10 @@
 package org.maripo.josm.easypresets.ui;
 
 import static org.openstreetmap.josm.tools.I18n.tr;
-
 import java.awt.event.ActionEvent;
-
 import org.openstreetmap.josm.actions.JosmAction;
 
+@SuppressWarnings("serial")
 public class ManagePresetsAction extends JosmAction {
 
 	public ManagePresetsAction () {
@@ -14,9 +13,9 @@ public class ManagePresetsAction extends JosmAction {
                 null, true);
 		
 	}
+	
 	@Override
 	public void actionPerformed(ActionEvent e) {
 		new ManagePresetsDialog().showDialog();
 	}
-
 }

--- a/src/org/maripo/josm/easypresets/ui/ManagePresetsDialog.java
+++ b/src/org/maripo/josm/easypresets/ui/ManagePresetsDialog.java
@@ -108,7 +108,10 @@ public class ManagePresetsDialog extends ExtendedDialog implements ListSelection
 			}
 		});
 		
-		refreshList();
+		//refreshList();
+		//list.clearSelection();
+		//list.setModel(model);
+
 		JScrollPane listScroll = new JScrollPane(list);
 		listScroll.setPreferredSize(new Dimension(320,420));
 		listPane.add(listScroll, GBC.std());
@@ -154,7 +157,6 @@ public class ManagePresetsDialog extends ExtendedDialog implements ListSelection
 			public void actionPerformed(ActionEvent e) {
 				copy();
 			}
-			
 		});
 		copyButton.setEnabled(false);
 		
@@ -195,7 +197,8 @@ public class ManagePresetsDialog extends ExtendedDialog implements ListSelection
 
 	private void refreshList() {
 		//presets = EasyPresets.getInstance().getPresets().toArray(new TaggingPresEasyPresetsPluginet[0]);
-		list.clearSelection();
+		System.out.printf("%s", list.toString());
+		//list.clearSelection();
 		//list.setListData(presets);
 	}
 
@@ -243,7 +246,7 @@ public class ManagePresetsDialog extends ExtendedDialog implements ListSelection
 	
 	private void delete() {
 		if (selectedPreset!=null) {
-			EasyPresets model = EasyPresets.getInstance();
+			//EasyPresets model = EasyPresets.getInstance();
 			model.removeElement(selectedPreset);
 			model.save();
 			EasyPresetsPlugin.groupMenu.updatePresetListMenu(model);
@@ -253,7 +256,7 @@ public class ManagePresetsDialog extends ExtendedDialog implements ListSelection
 
 	@Override
 	public void dispose() {
-		EasyPresets.getInstance().saveIfNeeded();
+		model.saveIfNeeded();
 		super.dispose();
 	}
 	
@@ -262,11 +265,13 @@ public class ManagePresetsDialog extends ExtendedDialog implements ListSelection
 	}
 
 	boolean isSelectionValid () {
+		//EasyPresets model = EasyPresets.getInstance();
 		return !(list.getSelectedIndex() < 0 || list.getSelectedIndex() >= model.size()); 
 	}
 	
 	@Override
 	public void valueChanged(ListSelectionEvent evt) {
+		//EasyPresets model = EasyPresets.getInstance();
 		int index = list.getSelectedIndex();
 		reorderUpButton.setEnabled(index>0);
 		reorderDownButton.setEnabled(index<model.size()-1);
@@ -291,7 +296,7 @@ public class ManagePresetsDialog extends ExtendedDialog implements ListSelection
 			return;
 		}
 		int index = list.getSelectedIndex();
-		EasyPresets.getInstance().moveUp(index);
+		model.moveUp(index);
 		refreshList();
 		list.setSelectedIndex(index-1);
 	}
@@ -301,7 +306,7 @@ public class ManagePresetsDialog extends ExtendedDialog implements ListSelection
 			return;
 		}
 		int index = list.getSelectedIndex();
-		EasyPresets.getInstance().moveDown(index);
+		model.moveDown(index);
 		refreshList();
 		list.setSelectedIndex(index+1);
 	}

--- a/src/org/maripo/josm/easypresets/ui/ManagePresetsDialog.java
+++ b/src/org/maripo/josm/easypresets/ui/ManagePresetsDialog.java
@@ -24,6 +24,7 @@ import javax.swing.UIManager;
 import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
 
+import org.maripo.josm.easypresets.EasyPresetsPlugin;
 import org.maripo.josm.easypresets.data.EasyPreset;
 import org.maripo.josm.easypresets.data.EasyPresets;
 import org.maripo.josm.easypresets.ui.editor.PresetEditorDialog;
@@ -193,7 +194,7 @@ public class ManagePresetsDialog extends ExtendedDialog implements ListSelection
 	}
 
 	private void refreshList() {
-		//presets = EasyPresets.getInstance().getPresets().toArray(new TaggingPreset[0]);
+		//presets = EasyPresets.getInstance().getPresets().toArray(new TaggingPresEasyPresetsPluginet[0]);
 		list.clearSelection();
 		//list.setListData(presets);
 	}
@@ -242,11 +243,14 @@ public class ManagePresetsDialog extends ExtendedDialog implements ListSelection
 	
 	private void delete() {
 		if (selectedPreset!=null) {
-			EasyPresets.getInstance().delete(selectedPreset);
+			EasyPresets model = EasyPresets.getInstance();
+			model.removeElement(selectedPreset);
+			model.save();
+			EasyPresetsPlugin.groupMenu.updatePresetListMenu(model);
 			refreshList();
 		}
 	}
-	
+
 	@Override
 	public void dispose() {
 		EasyPresets.getInstance().saveIfNeeded();

--- a/src/org/maripo/josm/easypresets/ui/ManagePresetsDialog.java
+++ b/src/org/maripo/josm/easypresets/ui/ManagePresetsDialog.java
@@ -195,6 +195,7 @@ public class ManagePresetsDialog extends ExtendedDialog implements ListSelection
 		System.out.println(msg);
 		//list.clearSelection();
 		//list.setListData(presets);
+		EasyPresetsPlugin.groupMenu.updatePresetListMenu(presets);
 	}
 
 	private void export() {
@@ -244,14 +245,12 @@ public class ManagePresetsDialog extends ExtendedDialog implements ListSelection
 		if (isSelectionValid()) {
 			presets.getModel().removeElement(getSelectedPreset());
 			presets.save();
-			EasyPresetsPlugin.groupMenu.updatePresetListMenu(presets);
 			refreshList("ManagePresetsDialog->delete()");
 		}
 	}
 
 	@Override
 	public void dispose() {
-		presets.saveIfNeeded();
 		super.dispose();
 	}
 	

--- a/src/org/maripo/josm/easypresets/ui/ManagePresetsDialog.java
+++ b/src/org/maripo/josm/easypresets/ui/ManagePresetsDialog.java
@@ -47,12 +47,12 @@ public class ManagePresetsDialog extends ExtendedDialog implements ListSelection
 
 	public ManagePresetsDialog () {
 		super(MainApplication.getMainFrame(), tr("Manage Custom Presets"));
-		model = EasyPresets.getInstance();
+		presets = EasyPresets.getInstance();
 		initUI();
 	}
 	
 	private TaggingPreset selectedPreset;
-	private EasyPresets model;
+	private EasyPresets presets;
 	JList<TaggingPreset> list;
 
 	private static class PresetRenderer extends JLabel implements ListCellRenderer<TaggingPreset> {
@@ -80,7 +80,7 @@ public class ManagePresetsDialog extends ExtendedDialog implements ListSelection
 	
 	}
 	private void initUI() {
-		list = new JList<TaggingPreset>(model);
+		list = new JList<TaggingPreset>(EasyPresets.getInstance().getModel());
 		list.setCellRenderer(new PresetRenderer());
 		final JPanel mainPane = new JPanel(new GridBagLayout());
 		
@@ -216,10 +216,10 @@ public class ManagePresetsDialog extends ExtendedDialog implements ListSelection
 
 	private boolean copy() {
 		if (selectedPreset!=null) {
-			int index = model.indexOf(selectedPreset);
+			int index = list.getSelectedIndex();
 			TaggingPreset copiedPreset = EasyPreset.copy(selectedPreset);
-			model.add(index+1, copiedPreset);
-			model.isDirty = true;
+			presets.getModel().insertElementAt(copiedPreset, index);
+			//presets.isDirty = true;
 			refreshList();
 			return true;
 		} else {
@@ -248,16 +248,16 @@ public class ManagePresetsDialog extends ExtendedDialog implements ListSelection
 	private void delete() {
 		if (selectedPreset!=null) {
 			//EasyPresets model = EasyPresets.getInstance();
-			model.removeElement(selectedPreset);
-			model.save();
-			EasyPresetsPlugin.groupMenu.updatePresetListMenu(model);
+			presets.getModel().removeElement(selectedPreset);
+			presets.save();
+			EasyPresetsPlugin.groupMenu.updatePresetListMenu(presets);
 			refreshList();
 		}
 	}
 
 	@Override
 	public void dispose() {
-		model.saveIfNeeded();
+		presets.saveIfNeeded();
 		super.dispose();
 	}
 	
@@ -267,7 +267,7 @@ public class ManagePresetsDialog extends ExtendedDialog implements ListSelection
 
 	boolean isSelectionValid () {
 		//EasyPresets model = EasyPresets.getInstance();
-		return !(list.getSelectedIndex() < 0 || list.getSelectedIndex() >= model.size()); 
+		return !(list.getSelectedIndex() < 0 || list.getSelectedIndex() >= presets.getModel().getSize()); 
 	}
 	
 	@Override
@@ -275,7 +275,7 @@ public class ManagePresetsDialog extends ExtendedDialog implements ListSelection
 		//EasyPresets model = EasyPresets.getInstance();
 		int index = list.getSelectedIndex();
 		reorderUpButton.setEnabled(index>0);
-		reorderDownButton.setEnabled(index<model.size()-1);
+		reorderDownButton.setEnabled(index < presets.getModel().getSize()-1);
 		
 		if (!isSelectionValid()) {
 			editButton.setEnabled(false);
@@ -285,7 +285,7 @@ public class ManagePresetsDialog extends ExtendedDialog implements ListSelection
 		editButton.setEnabled(true);
 		deleteButton.setEnabled(true);
 		copyButton.setEnabled(true);
-		select(model.elementAt(index));
+		select(presets.getModel().elementAt(index));
 	}
 
 	private void select(TaggingPreset preset) {
@@ -297,7 +297,7 @@ public class ManagePresetsDialog extends ExtendedDialog implements ListSelection
 			return;
 		}
 		int index = list.getSelectedIndex();
-		model.moveUp(index);
+		presets.moveUp(index);
 		refreshList();
 		list.setSelectedIndex(index-1);
 	}
@@ -307,7 +307,7 @@ public class ManagePresetsDialog extends ExtendedDialog implements ListSelection
 			return;
 		}
 		int index = list.getSelectedIndex();
-		model.moveDown(index);
+		presets.moveDown(index);
 		refreshList();
 		list.setSelectedIndex(index+1);
 	}
@@ -316,6 +316,7 @@ public class ManagePresetsDialog extends ExtendedDialog implements ListSelection
 	@Override
 	public void onCancel() {
 		// Do nothing
+		refreshList();
 	}
 
 	@Override

--- a/src/org/maripo/josm/easypresets/ui/ManagePresetsDialog.java
+++ b/src/org/maripo/josm/easypresets/ui/ManagePresetsDialog.java
@@ -209,7 +209,8 @@ public class ManagePresetsDialog extends ExtendedDialog implements ListSelection
 	protected void edit() {
 		// Open 
 		if (selectedPreset!=null) {
-			new PresetEditorDialog(selectedPreset).showDialog(this);
+			int index = list.getSelectedIndex();
+			new PresetEditorDialog(selectedPreset, index).showDialog(this);
 		}
 	}
 

--- a/src/org/maripo/josm/easypresets/ui/ManagePresetsDialog.java
+++ b/src/org/maripo/josm/easypresets/ui/ManagePresetsDialog.java
@@ -51,7 +51,6 @@ public class ManagePresetsDialog extends ExtendedDialog implements ListSelection
 		initUI();
 	}
 	
-	private TaggingPreset selectedPreset;
 	private EasyPresets presets;
 	JList<TaggingPreset> list;
 
@@ -108,10 +107,6 @@ public class ManagePresetsDialog extends ExtendedDialog implements ListSelection
 			}
 		});
 		
-		//refreshList();
-		//list.clearSelection();
-		//list.setModel(model);
-
 		JScrollPane listScroll = new JScrollPane(list);
 		listScroll.setPreferredSize(new Dimension(320,420));
 		listPane.add(listScroll, GBC.std());
@@ -195,9 +190,9 @@ public class ManagePresetsDialog extends ExtendedDialog implements ListSelection
 		setContent(mainPane);
 	}
 
-	private void refreshList() {
+	private void refreshList(String msg) {
 		//presets = EasyPresets.getInstance().getPresets().toArray(new TaggingPresEasyPresetsPluginet[0]);
-		System.out.printf("%s", list.toString());
+		System.out.println(msg);
 		//list.clearSelection();
 		//list.setListData(presets);
 	}
@@ -208,19 +203,19 @@ public class ManagePresetsDialog extends ExtendedDialog implements ListSelection
 			
 	protected void edit() {
 		// Open 
-		if (selectedPreset!=null) {
+		if (isSelectionValid()) {
 			int index = list.getSelectedIndex();
-			new PresetEditorDialog(selectedPreset, index).showDialog(this);
+			new PresetEditorDialog(getSelectedPreset(), index).showDialog(this);
 		}
 	}
 
 	private boolean copy() {
-		if (selectedPreset!=null) {
+		if (isSelectionValid()) {
 			int index = list.getSelectedIndex();
-			TaggingPreset copiedPreset = EasyPreset.copy(selectedPreset);
+			TaggingPreset copiedPreset = EasyPreset.copy(getSelectedPreset());
 			presets.getModel().insertElementAt(copiedPreset, index);
 			//presets.isDirty = true;
-			refreshList();
+			refreshList("ManagePresetsDialog->copy()");
 			return true;
 		} else {
 			return false;
@@ -234,7 +229,7 @@ public class ManagePresetsDialog extends ExtendedDialog implements ListSelection
 			tr("Delete"),
 			tr("Cancel")
 		);
-		dialog.setContent(tr("Are you sure you want to delete \"{0}\"?",selectedPreset.getName()));
+		dialog.setContent(tr("Are you sure you want to delete \"{0}\"?",getSelectedPreset().getName()));
 		dialog.setButtonIcons("ok", "cancel");
 		dialog.setModalityType(ModalityType.APPLICATION_MODAL);
 		dialog.setAlwaysOnTop(true);
@@ -246,12 +241,11 @@ public class ManagePresetsDialog extends ExtendedDialog implements ListSelection
 	
 	
 	private void delete() {
-		if (selectedPreset!=null) {
-			//EasyPresets model = EasyPresets.getInstance();
-			presets.getModel().removeElement(selectedPreset);
+		if (isSelectionValid()) {
+			presets.getModel().removeElement(getSelectedPreset());
 			presets.save();
 			EasyPresetsPlugin.groupMenu.updatePresetListMenu(presets);
-			refreshList();
+			refreshList("ManagePresetsDialog->delete()");
 		}
 	}
 
@@ -266,13 +260,11 @@ public class ManagePresetsDialog extends ExtendedDialog implements ListSelection
 	}
 
 	boolean isSelectionValid () {
-		//EasyPresets model = EasyPresets.getInstance();
 		return !(list.getSelectedIndex() < 0 || list.getSelectedIndex() >= presets.getModel().getSize()); 
 	}
 	
 	@Override
 	public void valueChanged(ListSelectionEvent evt) {
-		//EasyPresets model = EasyPresets.getInstance();
 		int index = list.getSelectedIndex();
 		reorderUpButton.setEnabled(index>0);
 		reorderDownButton.setEnabled(index < presets.getModel().getSize()-1);
@@ -285,11 +277,14 @@ public class ManagePresetsDialog extends ExtendedDialog implements ListSelection
 		editButton.setEnabled(true);
 		deleteButton.setEnabled(true);
 		copyButton.setEnabled(true);
-		select(presets.getModel().elementAt(index));
 	}
-
-	private void select(TaggingPreset preset) {
-		selectedPreset = preset;
+	
+	TaggingPreset getSelectedPreset() {
+		if (isSelectionValid()) {
+			int index = list.getSelectedIndex();
+			return presets.getModel().elementAt(index);
+		}
+		return null;
 	}
 	
 	private void reorderUp () {
@@ -298,7 +293,7 @@ public class ManagePresetsDialog extends ExtendedDialog implements ListSelection
 		}
 		int index = list.getSelectedIndex();
 		presets.moveUp(index);
-		refreshList();
+		refreshList("ManagePresetsDialog->reorderUp()");
 		list.setSelectedIndex(index-1);
 	}
 	
@@ -308,7 +303,7 @@ public class ManagePresetsDialog extends ExtendedDialog implements ListSelection
 		}
 		int index = list.getSelectedIndex();
 		presets.moveDown(index);
-		refreshList();
+		refreshList("ManagePresetsDialog->reorderDown()");
 		list.setSelectedIndex(index+1);
 	}
 
@@ -316,11 +311,11 @@ public class ManagePresetsDialog extends ExtendedDialog implements ListSelection
 	@Override
 	public void onCancel() {
 		// Do nothing
-		refreshList();
+		refreshList("ManagePresetsDialog->onCancel()");
 	}
 
 	@Override
 	public void onSave() {
-		refreshList();
+		refreshList("ManagePresetsDialog->onSave()");
 	}
 }

--- a/src/org/maripo/josm/easypresets/ui/editor/PresetEditorDialog.java
+++ b/src/org/maripo/josm/easypresets/ui/editor/PresetEditorDialog.java
@@ -25,6 +25,7 @@ import javax.swing.JScrollPane;
 import javax.swing.JTextField;
 import javax.swing.SwingUtilities;
 
+import org.maripo.josm.easypresets.data.EasyPreset;
 import org.maripo.josm.easypresets.data.EasyPresets;
 import org.maripo.josm.easypresets.ui.editor.IconPickerDialog.IconPickerDialogListener;
 import org.openstreetmap.josm.gui.ExtendedDialog;
@@ -306,9 +307,20 @@ public class PresetEditorDialog extends ExtendedDialog {
 			// TODO support multiple errors
 			return;
 		}
-		if (presetToEdit!=null) {
-			applyToPreset(presetToEdit);
-			EasyPresets.getInstance().setElementAt(presetToEdit, index);
+		
+		if (presetToEdit != null) {
+			String str = uiPresetName.getText().trim();
+			if ((str == null) || (str.length() < 1)) {
+				uiPresetName.setText(presetToEdit.getName());
+			}
+
+			TaggingPreset preset = applyToPreset(presetToEdit);
+
+			System.out.printf("\nname: %s\n", name);
+			System.out.printf("uiPresetName: %s\n", uiPresetName.getText());
+			System.out.printf("preset: %s\n", preset.getName());
+			
+			EasyPresets.getInstance().setElementAt(preset, index);
 		} else {
 			// New preset
 			EasyPresets.getInstance().addElement(createPreset());
@@ -367,7 +379,8 @@ public class PresetEditorDialog extends ExtendedDialog {
 	private TaggingPreset createPreset () {
 		return applyToPreset(new TaggingPreset());
 	}
-	private TaggingPreset applyToPreset(final TaggingPreset preset) {
+	private TaggingPreset applyToPreset(final TaggingPreset src) {
+		EasyPreset preset = EasyPreset.clone(src);
 		preset.name = uiPresetName.getText();
 		preset.data.clear();
 		if (iconPath!=null) {

--- a/src/org/maripo/josm/easypresets/ui/editor/PresetEditorDialog.java
+++ b/src/org/maripo/josm/easypresets/ui/editor/PresetEditorDialog.java
@@ -60,6 +60,7 @@ public class PresetEditorDialog extends ExtendedDialog {
 	private String referenceURL;
 	private TaggingPreset presetToEdit;
 	protected Collection<TaggingPresetType> defaultTypes;
+	private int index = -1;
 	
 	/**
 	 * Create new preset (Initialize with tags and types extracted from selection)
@@ -84,8 +85,9 @@ public class PresetEditorDialog extends ExtendedDialog {
 	 * Edit existing preset (Initialize with existing TaggingPreset object)
 	 * @param preset
 	 */
-	public PresetEditorDialog (TaggingPreset preset) {
+	public PresetEditorDialog (TaggingPreset preset, int index) {
 		super(MainApplication.getMainFrame(), tr("Preset Editor"));
+		this.index = index;
 		name = preset.name;
 		referenceURL = findURL(preset);
 		icon = preset.getIcon();
@@ -306,6 +308,7 @@ public class PresetEditorDialog extends ExtendedDialog {
 		}
 		if (presetToEdit!=null) {
 			applyToPreset(presetToEdit);
+			EasyPresets.getInstance().setElementAt(presetToEdit, index);
 		} else {
 			// New preset
 			EasyPresets.getInstance().addElement(createPreset());

--- a/src/org/maripo/josm/easypresets/ui/editor/PresetEditorDialog.java
+++ b/src/org/maripo/josm/easypresets/ui/editor/PresetEditorDialog.java
@@ -42,6 +42,7 @@ import org.openstreetmap.josm.tools.ImageProvider.ImageSizes;
  * @author maripo
  *
  */
+@SuppressWarnings("serial")
 public class PresetEditorDialog extends ExtendedDialog {
 	
 	public static interface PresetEditorDialogListener {
@@ -307,7 +308,7 @@ public class PresetEditorDialog extends ExtendedDialog {
 			applyToPreset(presetToEdit);
 		} else {
 			// New preset
-			EasyPresets.getInstance().add(createPreset());
+			EasyPresets.getInstance().addElement(createPreset());
 		}
 		EasyPresets.getInstance().save();
 		if (dialogListener != null) {


### PR DESCRIPTION
Modified so that the edited result in the PresetEditorDialog is reflected to the ManagePresetsDialog and the GroupPresetMenu without restarting JOSM.

PresetEditorDialogでの編集結果がJOSMを再起動しなくてもManagePresetsDialogとGroupPresetMenuに反映されるように修正しました。